### PR TITLE
fix: clipboard doesn't work on safari

### DIFF
--- a/src/components/svgInfo.tsx
+++ b/src/components/svgInfo.tsx
@@ -27,14 +27,33 @@ const downloadSvg = (url?: string) => {
   download(url || "");
 };
 
+
+const MIMETYPE = 'text/plain';
+
+// Return content of svg as blob =>
+const getSvgContent = async (url: string | undefined, isSupported: boolean) => {
+  const response =  await fetch(url || "");
+  const content = await response.text(); 
+
+  // It was necessary to use blob because in chrome there were issues with the copy to clipboard
+  const blob = new Blob([content], { type: MIMETYPE });
+  return isSupported ? blob : content;
+}
+
 // Copy to clipboard =>
-const copyToClipboard = (url?: string) => {
-  fetch(url || "").then((response) => {
-    response.text().then((content) => {
-      navigator.clipboard.writeText(content);
-      toast("Copied to clipboard", ToastTheme);
-    });
-  });
+const copyToClipboard = async (url?: string) => {
+  const data = {
+    [MIMETYPE]: getSvgContent(url, true)
+  };
+  try {
+    const clipboardItem = new ClipboardItem(data);
+    await navigator.clipboard.write([clipboardItem]);
+  } catch (error) {
+    // This section works as a fallback on Firefox
+    const content = await getSvgContent(url, false) as string;
+    await navigator.clipboard.writeText(content);
+  }
+  toast("Copied to clipboard", ToastTheme);
 };
 
 const SVGInfo = (props: SVGCardProps) => {


### PR DESCRIPTION
I've solved the issue about clipboard on safari. Basically, we can't use the **writeText** and **write** functions in the following contexts: 
1. Trying to copy a string as a result of a promise.
2. If we use await and then the functions mentioned above, it will throw an exception because Apple doesn't allow this. [Check this answer on stackoverflow](https://stackoverflow.com/questions/66312944/javascript-clipboard-api-write-does-not-work-in-safari#:~:text=It%27s%20because%20of%20your%20await%20call%20before%20calling%20clipboard.write.%20Apple%20doesn%27t%20allow%20this.%20You%20have%20to%20pass%20your%20promise%20directly%20into%20ClipboardItem%20like%20this%3A). 

So, for that reason it was necessary to create a method `getSvgContent` to fetch data. I based on this documentation:  [Webkit clipboard](https://webkit.org/blog/10855/async-clipboard-api/#:~:text=%3C/script%3E-,When,-using%20clipboard.write) to create it. 
After that, it was able to copy svg's content on safari. However, there were troubles on Chrome because the function `write` not allow to copy strings. I ended up following [this tutorial](https://web.dev/async-clipboard/#handling-multiple-file-types), as you can see 
```
async function copy() {
  const image = await fetch('kitten.png').then(response => response.blob());
  const text = new Blob(['Cute sleeping kitten'], {type: 'text/plain'});
  const item = new ClipboardItem({
    'text/plain': text,
    'image/png': image
  });
  await navigator.clipboard.write([item]);
}
```
It is necessary to use Blob if we want to copy a text. Finally, another issue was that **ClipboardItem** is not supported on Firefox, hence inside of catch block, there is a logic when a user try to copy svg's content on Firefox. You can see it like a fallback. [See the compatibility](https://caniuse.com/?search=ClipboardItem).


Before PR

https://user-images.githubusercontent.com/68721455/183276400-af58d880-892d-43a8-b7ca-50a4ada879dc.mov

After PR

https://user-images.githubusercontent.com/68721455/183276405-8f600877-9c02-4e3d-920a-4c66ab0353bc.mov

Tested on Safari(15.6) , Chrome(103.0), Microsoft Edge(104.0), Firefox(103.0.1) and Opera(89.0)

BTW, I didn't test on iOS and iPadOS
