### PR TITLE
fix: avoid displaying search bar twice on mobile devices

### DIFF
--- a/src/layout/header/index.tsx
+++ b/src/layout/header/index.tsx
@@ -93,7 +93,7 @@ const Header = () => {
             </HStack>
           </Flex>
           <Collapse in={isOpen} animateOpacity>
-            <Box mt="3">
+            <Box mt="3" display={{ base:"none", md:"block" }}>
               <Search />
             </Box>
           </Collapse>


### PR DESCRIPTION
### Problem
When the search bar is opened in Desktop version and then the window is resized to Mobile version, the search bar is displayed twice, the one for Desktop version and the one for Mobile version.

#### Search bar current behavior

https://user-images.githubusercontent.com/33623712/183767119-c5d3551c-3be2-4900-81f0-74605df330cc.mp4

#### Search bar behavior after PR

https://user-images.githubusercontent.com/33623712/183767130-0487f1a1-e76f-4e10-8b0d-fed81c496b69.mp4

#### Tested on: 

- **_Chrome 104.0_**
- **_Firefox 103.0_**
- **_Edge 104.0_**


