### PR TITLE
Webstrom, phpstorm, pycharm, rubytime and fleet logos added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn.lock
 /.svelte-kit
 /build
 /package
+.idea/
 
 # Logs
 .DS_Store

--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -1845,5 +1845,41 @@ export const svgs: iSVG[] = [
     category: 'Social',
     route: '/library/meta.svg',
     url: 'https://meta.com/'
+  },
+  {
+    title: 'JetBrains WebStorm',
+    category: 'Software',
+    route: '/library/webstorm.svg',
+    url: 'https://www.jetbrains.com/webstorm/'
+  },
+  {
+    title: 'JetBrains PyCharm',
+    category: 'Software',
+    route: '/library/pycharm.svg',
+    url: 'https://www.jetbrains.com/pycharm/'
+  },
+  {
+    title: 'JetBrains Fleet',
+    category: 'Software',
+    route: '/library/fleet.svg',
+    url: 'https://www.jetbrains.com/fleet/'
+  },
+  {
+    title: 'JetBrains RubyMine',
+    category: 'Software',
+    route: '/library/rubymine.svg',
+    url: 'https://www.jetbrains.com/ruby/'
+  },
+  {
+    title: 'JetBrains PhpStorm',
+    category: 'Software',
+    route: '/library/phpstorm.svg',
+    url: 'https://www.jetbrains.com/phpstorm/'
+  },
+  {
+    title: 'JetBrains PyCharm',
+    category: 'Software',
+    route: '/library/pycharm.svg',
+    url: 'https://www.jetbrains.com/pycharm/'
   }
 ];

--- a/static/library/fleet.svg
+++ b/static/library/fleet.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 70 70">
+  <defs>
+    <radialGradient id="a" cx="0" cy="0" r="1" gradientTransform="matrix(22.35433 -20.58122 27.17129 29.51214 38.648 42.538)" gradientUnits="userSpaceOnUse">
+      <stop offset=".771" stop-color="#001AFF"/>
+      <stop offset="1" stop-color="#8ACEFF"/>
+    </radialGradient>
+    <radialGradient id="b" cx="0" cy="0" r="1" gradientTransform="rotate(-30.543 79.837 -70.068) scale(16.777 22.1489)" gradientUnits="userSpaceOnUse">
+      <stop offset=".719" stop-color="#FA00FF" stop-opacity="0"/>
+      <stop offset="1" stop-color="#FF00D6" stop-opacity=".44"/>
+    </radialGradient>
+    <radialGradient id="c" cx="0" cy="0" r="1" gradientTransform="rotate(49.385 -19.814 41.858) scale(47.8852)" gradientUnits="userSpaceOnUse">
+      <stop offset=".026" stop-color="#8DFDFD"/>
+      <stop offset=".271" stop-color="#87FBFB"/>
+      <stop offset=".484" stop-color="#74D6F4"/>
+      <stop offset=".932" stop-color="#0038FF"/>
+    </radialGradient>
+    <radialGradient id="d" cx="0" cy="0" r="1" gradientTransform="rotate(137.237 9.434 23.195) scale(32.8316)" gradientUnits="userSpaceOnUse">
+      <stop offset=".267" stop-color="#0500FF" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0500FF" stop-opacity=".15"/>
+    </radialGradient>
+    <radialGradient id="e" cx="0" cy="0" r="1" gradientTransform="rotate(75.198 -4.629 32.631) scale(51.1484)" gradientUnits="userSpaceOnUse">
+      <stop offset=".42" stop-color="#FF00E5" stop-opacity="0"/>
+      <stop offset=".774" stop-color="#FF00F5" stop-opacity=".64"/>
+      <stop offset=".899" stop-color="#BE46FF" stop-opacity=".87"/>
+    </radialGradient>
+    <radialGradient id="g" cx="0" cy="0" r="1" gradientTransform="matrix(2.73484 22.75837 -34.39872 4.13365 29.458 35.276)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00B2FF"/>
+      <stop offset=".571" stop-color="#74C5FF"/>
+      <stop offset=".979" stop-color="#9FD7FF"/>
+    </radialGradient>
+    <linearGradient id="f" x1="11.644" x2="82.363" y1="42.432" y2="43.401" gradientUnits="userSpaceOnUse">
+      <stop offset=".432" stop-color="#FE62EE" stop-opacity="0"/>
+      <stop offset=".818" stop-color="#FD3AF5" stop-opacity=".47"/>
+    </linearGradient>
+    <linearGradient id="h" x1="33.054" x2="37.35" y1="23.191" y2="49.344" gradientUnits="userSpaceOnUse">
+      <stop offset=".042" stop-color="#0038FF"/>
+      <stop offset=".724" stop-color="#48BFF1" stop-opacity=".59"/>
+      <stop offset="1" stop-color="#74C5FF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#a)" d="M65.153 30.85c0 9.496-10.163 17.194-22.7 17.194-12.536 0-22.699-7.698-22.699-17.194 0-9.496 10.163-17.194 22.7-17.194 12.536 0 22.699 7.698 22.699 17.194z"/>
+  <path fill="url(#b)" d="M65.153 30.85c0 9.496-10.163 17.194-22.7 17.194-12.536 0-22.699-7.698-22.699-17.194 0-9.496 10.163-17.194 22.7-17.194 12.536 0 22.699 7.698 22.699 17.194z"/>
+  <path fill="url(#c)" d="M66 35c0 17.12-13.88 31-31 31C17.88 66 4 52.12 4 35 4 17.88 17.88 4 35 4c8.046 3.642 16.464 17.194 19.99 21.429 3.524 4.235 12.648 9.571 8.176-1.623C65.073 26.832 66 31.852 66 35z"/>
+  <path fill="url(#d)" d="M66 35c0 17.12-13.88 31-31 31C17.88 66 4 52.12 4 35 4 17.88 17.88 4 35 4c8.046 3.642 16.464 17.194 19.99 21.429 3.524 4.235 12.648 9.571 8.176-1.623C65.073 26.832 66 31.852 66 35z"/>
+  <path fill="url(#e)" d="M66 35c0 17.12-13.88 31-31 31C17.88 66 4 52.12 4 35 4 17.88 17.88 4 35 4c8.046 3.642 16.464 17.194 19.99 21.429 3.524 4.235 12.648 9.571 8.176-1.623C65.073 26.832 66 31.852 66 35z"/>
+  <path fill="url(#f)" d="M66 35c0 17.12-13.88 31-31 31C17.88 66 4 52.12 4 35 4 17.88 17.88 4 35 4c8.046 3.642 16.464 17.194 19.99 21.429 3.524 4.235 12.648 9.571 8.176-1.623C65.073 26.832 66 31.852 66 35z"/>
+  <path fill="url(#g)" d="M56.651 39.682c1.658 7.764-6.511 16.089-18.246 18.594-11.734 2.505-22.59-1.757-24.248-9.52-1.658-7.764 6.511-16.089 18.246-18.594 11.734-2.506 22.59 1.757 24.248 9.52z"/>
+  <path fill="url(#h)" d="M56.651 39.682c1.658 7.764-6.511 16.089-18.246 18.594-11.734 2.505-22.59-1.757-24.248-9.52-1.658-7.764 6.511-16.089 18.246-18.594 11.734-2.506 22.59 1.757 24.248 9.52z"/>
+  <path fill="#D6F8F8" fill-opacity=".19" fill-rule="evenodd" d="M51.462 49.883c3.074-3.133 4.386-6.66 3.698-9.882-.688-3.223-3.326-5.907-7.411-7.51-4.073-1.6-9.412-2.037-15.028-.838-5.616 1.199-10.31 3.779-13.375 6.901-3.074 3.133-4.386 6.66-3.698 9.883.688 3.223 3.326 5.906 7.412 7.51 4.072 1.6 9.41 2.037 15.027.838 5.616-1.2 10.31-3.779 13.375-6.902zm-13.057 8.393c11.735-2.505 19.904-10.83 18.246-18.594-1.658-7.763-12.514-12.026-24.248-9.52-11.735 2.505-19.904 10.83-18.246 18.593 1.658 7.764 12.514 12.026 24.248 9.521z" clip-rule="evenodd"/>
+</svg>

--- a/static/library/phpstorm.svg
+++ b/static/library/phpstorm.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 105 105">
+  <defs>
+    <linearGradient id="a" x1="22.6999" x2="49.8075" y1="60.3539" y2="8.29501" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#AF1DF5"/>
+      <stop offset=".2116" stop-color="#BC20E4"/>
+      <stop offset=".62822" stop-color="#DD29B8"/>
+      <stop offset="1" stop-color="#FF318C"/>
+    </linearGradient>
+    <linearGradient id="b" x1="14.9194" x2="47.7774" y1="76.2786" y2="32.8766" gradientUnits="userSpaceOnUse">
+      <stop offset=".01613" stop-color="#6B57FF"/>
+      <stop offset=".42357" stop-color="#B74AF7"/>
+      <stop offset=".74587" stop-color="#FF318C"/>
+    </linearGradient>
+    <linearGradient id="c" x1="89.2615" x2="71.054" y1="64.5639" y2="21.3514" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#293896"/>
+      <stop offset=".07538" stop-color="#3B3AA2"/>
+      <stop offset=".2871" stop-color="#6740C0"/>
+      <stop offset=".49127" stop-color="#8A44D8"/>
+      <stop offset=".68315" stop-color="#A347E9"/>
+      <stop offset=".85788" stop-color="#B249F3"/>
+      <stop offset="1" stop-color="#B74AF7"/>
+    </linearGradient>
+    <linearGradient id="d" x1="74.3402" x2="44.0706" y1="90.0655" y2="45.6976" gradientUnits="userSpaceOnUse">
+      <stop offset=".01613" stop-color="#6B57FF"/>
+      <stop offset=".78291" stop-color="#B74AF7"/>
+    </linearGradient>
+    <linearGradient id="e" x1="65.1658" x2="55.1373" y1="66.2504" y2="13.2147" gradientUnits="userSpaceOnUse">
+      <stop offset=".01613" stop-color="#6B57FF"/>
+      <stop offset=".63699" stop-color="#B74AF7"/>
+    </linearGradient>
+    <linearGradient id="f" x1="15.9224" x2="31.5438" y1="43.2243" y2="14.8744" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#AF1DF5"/>
+      <stop offset=".2116" stop-color="#BC20E4"/>
+      <stop offset=".62822" stop-color="#DD29B8"/>
+      <stop offset="1" stop-color="#FF318C"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#a)" d="m57.9928 21.8765-3.2018-9.6773-14.8597 7.1828-19.671 1.7355 2.7 33.75 27.8985-4.6688 7.134-28.3222Z"/>
+  <path fill="url(#b)" d="M31.4795 30.491 5 23.5325l9.1515 54.9577 49.3087-.48L31.4795 30.491Z"/>
+  <path fill="url(#c)" d="m67.8957 53.903-11.379-19.4783 12.3435-11.1855 19.647-8.0407L101 46.2447 83.0082 64.1142 67.8957 53.903Z"/>
+  <path fill="url(#d)" d="m83.0165 45.8315-6.2497-12.7568-49.0073 9.8468 5.034 46.7947L65.147 101 101 79.5395l-17.9835-33.708Z"/>
+  <path fill="url(#e)" d="m57.674 48.1175-29.9145-5.196L64.274 10.6992l24.2333 4.4993L73.4885 30.182l3.471 3.0855-19.2855 14.85Z"/>
+  <path fill="url(#f)" d="M54.791 12.1992 21.3762 5 5 23.5325l26.5267 7.0522L54.791 12.1992Z"/>
+  <path fill="#000" d="M83 23H23v60h60V23Z"/>
+  <path fill="#fff" d="M53 71.75H30.5v3.75H53v-3.75Zm-2.8562-21.7299 2.9351-3.513c2.0295 1.6744 4.1596 2.7394 6.7347 2.7394 2.0347 0 3.2585-.8054 3.2584-2.1301v-.0636c-.0001-1.2558-.7737-1.9022-4.5464-2.8666-4.5462-1.1604-7.4818-2.4214-7.4821-6.8988v-.0689c-.0003-4.0905 3.2899-6.8035 7.8997-6.8035 3.0435-.049 6.0086.9668 8.3826 2.8719l-2.5801 3.7409c-1.9976-1.3883-3.9635-2.2255-5.8657-2.2255-1.9023 0-2.9036.869-2.9035 1.9658v.0636c.0001 1.4836.9698 1.9711 4.8696 2.9672 4.578 1.1922 7.1586 2.8401 7.1589 6.7717v.0636c.0003 4.4827-3.417 6.9943-8.2865 6.9943-3.5263.0131-6.9342-1.2712-9.5747-3.6084m-19.576-19.2623h9.1816c5.3598 0 8.6022 3.1782 8.6022 7.7678v.0642c0 5.2001-4.0448 7.8969-9.0845 7.8969h-3.7559v6.7407h-4.9434V30.7578Zm8.8598 11.3311c2.4721 0 3.9164-1.4763 3.9164-3.4028v-.0642c0-2.2146-1.5405-3.402-4.0127-3.402h-3.8201v6.869h3.9164Z"/>
+</svg>

--- a/static/library/pycharm.svg
+++ b/static/library/pycharm.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 105 105">
+  <linearGradient id="a" x1="38.78" x2="95.91" y1="41.59" y2="41.59" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#21d789"/>
+    <stop offset="1" stop-color="#07c3f2"/>
+  </linearGradient>
+  <linearGradient id="b" x1="-29.18" x2="88.46" y1="85.52" y2="-1.32" gradientUnits="userSpaceOnUse">
+    <stop offset=".01" stop-color="#fcf84a"/>
+    <stop offset=".11" stop-color="#a7eb62"/>
+    <stop offset=".21" stop-color="#5fe077"/>
+    <stop offset=".27" stop-color="#32da84"/>
+    <stop offset=".31" stop-color="#21d789"/>
+    <stop offset=".58" stop-color="#21d789"/>
+    <stop offset=".6" stop-color="#21d789"/>
+    <stop offset=".69" stop-color="#20d68c"/>
+    <stop offset=".76" stop-color="#1ed497"/>
+    <stop offset=".83" stop-color="#19d1a9"/>
+    <stop offset=".9" stop-color="#13ccc2"/>
+    <stop offset=".97" stop-color="#0bc6e1"/>
+    <stop offset="1" stop-color="#07c3f2"/>
+  </linearGradient>
+  <linearGradient id="c" x1="17.3" x2="36.92" y1="110.99" y2="49.42" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#21d789"/>
+    <stop offset=".16" stop-color="#24d888"/>
+    <stop offset=".3" stop-color="#2fd985"/>
+    <stop offset=".43" stop-color="#41dc80"/>
+    <stop offset=".55" stop-color="#5ae079"/>
+    <stop offset=".67" stop-color="#7ae46f"/>
+    <stop offset=".79" stop-color="#a1ea64"/>
+    <stop offset=".9" stop-color="#cff157"/>
+    <stop offset="1" stop-color="#fcf84a"/>
+  </linearGradient>
+  <linearGradient id="d" x1="43.28" x2="85.97" y1="57.46" y2=".06" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#21d789"/>
+    <stop offset=".09" stop-color="#23d986"/>
+    <stop offset=".17" stop-color="#2ade7b"/>
+    <stop offset=".25" stop-color="#36e669"/>
+    <stop offset=".27" stop-color="#3bea62"/>
+    <stop offset=".35" stop-color="#47eb61"/>
+    <stop offset=".49" stop-color="#67ed5d"/>
+    <stop offset=".69" stop-color="#9af156"/>
+    <stop offset=".92" stop-color="#e0f64d"/>
+    <stop offset="1" stop-color="#fcf84a"/>
+  </linearGradient>
+  <linearGradient id="e" x1="108.58" x2="22.55" y1="64.77" y2="63.97" gradientUnits="userSpaceOnUse">
+    <stop offset=".39" stop-color="#fcf84a"/>
+    <stop offset=".46" stop-color="#ecf74c"/>
+    <stop offset=".61" stop-color="#c1f451"/>
+    <stop offset=".82" stop-color="#7eef5a"/>
+    <stop offset="1" stop-color="#3bea62"/>
+  </linearGradient>
+  <path fill="url(#a)" d="m71.81 19.65 28.05 23.33-10.1 20.55-16.91-4.69H58.22z"/>
+  <path fill="url(#b)" d="m43.55 34.8-5.43 28.73-.52 9.76-13.69 5.93L4.5 81.31l5.89-62.07L45.56 4.5l21.67 14.21z"/>
+  <path fill="url(#c)" d="m43.55 34.8 2.64 55.36-8.77 10.34L4.5 81.31l27.03-40.28z"/>
+  <path fill="url(#d)" d="M79.77 30.76H46.51L75.9 4.5z"/>
+  <path fill="url(#e)" d="m100.5 90.38-29.28 9.94-38.99-10.98L43.55 34.8l4.52-4.04 23.74-2.23-2.15 23.84 18.88-7.32z"/>
+  <path d="M22.5 22.5h60v60h-60z"/>
+  <path fill="#fff" d="M29.98 71.16h22.5v3.75h-22.5zM30 30h9.2c5.36 0 8.61 3.18 8.61 7.77v.06c0 5.2-4.05 7.9-9.09 7.9H35v6.74h-5zm8.86 11.33c2.47 0 3.92-1.47 3.92-3.4v-.06c0-2.22-1.54-3.41-4-3.41H35v6.87zm11.63-.02v-.06A11.41 11.41 0 0 1 62.2 29.63a11.59 11.59 0 0 1 8.86 3.46l-3.14 3.63a8.33 8.33 0 0 0-5.75-2.54c-3.79 0-6.52 3.15-6.52 7v.07c0 3.85 2.67 7.06 6.52 7.06 2.57 0 4.14-1 5.91-2.63l3.14 3.17a11.46 11.46 0 0 1-9.21 4 11.35 11.35 0 0 1-11.52-11.54"/>
+</svg>

--- a/static/library/rubymine.svg
+++ b/static/library/rubymine.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 105 105">
+  <linearGradient id="a" x1="65.05" x2="52.91" y1="60.03" y2="28.18" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#fe2857"/>
+    <stop offset=".06" stop-color="#fe3052"/>
+    <stop offset=".33" stop-color="#fd533b"/>
+    <stop offset=".58" stop-color="#fc6c2a"/>
+    <stop offset=".81" stop-color="#fc7b20"/>
+    <stop offset="1" stop-color="#fc801d"/>
+  </linearGradient>
+  <linearGradient id="b" x1="41.93" x2="60.67" y1="14.45" y2="31.63" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#6b57ff"/>
+    <stop offset="1" stop-color="#fe2857"/>
+  </linearGradient>
+  <linearGradient id="c" x1="3.92" x2="65.63" y1="19.88" y2="98.32" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#6b57ff"/>
+    <stop offset=".3" stop-color="#fe2857"/>
+    <stop offset=".63" stop-color="#fe2857"/>
+    <stop offset=".64" stop-color="#fe3052"/>
+    <stop offset=".7" stop-color="#fd533b"/>
+    <stop offset=".76" stop-color="#fc6c2a"/>
+    <stop offset=".81" stop-color="#fc7b20"/>
+    <stop offset=".85" stop-color="#fc801d"/>
+  </linearGradient>
+  <path fill="url(#a)" d="m83.34 4.5-27.47 9.84L34.22 4.5l-7.13 17.96h-4.61v53.02l66.67.58 10.35-52.8z"/>
+  <path fill="url(#b)" d="m82.52 38.95-43.87-26 43.87 51.42z"/>
+  <path fill="url(#c)" d="m43.46 98 35.88-4.78-5.57-10.71h8.75V64.37l-43.88-51.5L3.5 21.5l.04 50.4 20.2 28.6 19.61-2.49.09-.01z"/>
+  <path d="M22.5 22.5h60v60h-60z"/>
+  <path fill="#fff" d="M29.98 71.16h22.5v3.75h-22.5zm22.23-41.19h5.35l5.93 9.54 5.93-9.54h5.35v22.55h-4.93V37.8l-6.35 9.63h-.13l-6.28-9.53v14.62h-4.87zM30 30h10.3q4.28 0 6.56 2.28a7 7 0 0 1 1.93 5.15v.07a7 7 0 0 1-1.34 4.45 7.74 7.74 0 0 1-3.49 2.53l5.51 8h-5.8L39 45.57h-4.09v6.92H30zm10 10.91a4.12 4.12 0 0 0 2.77-.91 3 3 0 0 0 1-2.32v-.06a2.85 2.85 0 0 0-1-2.41 4.53 4.53 0 0 0-2.86-.81h-4.98v6.47z"/>
+</svg>

--- a/static/library/webstorm.svg
+++ b/static/library/webstorm.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 105 105">
+  <linearGradient id="a" x1="38.88" x2="63.72" y1="6.5" y2="95.94" gradientUnits="userSpaceOnUse">
+    <stop offset=".28" stop-color="#07c3f2"/>
+    <stop offset=".94" stop-color="#087cfa"/>
+  </linearGradient>
+  <linearGradient id="b" x1="46.63" x2="88.66" y1="17.85" y2="79.48" gradientUnits="userSpaceOnUse">
+    <stop offset=".14" stop-color="#fcf84a"/>
+    <stop offset=".37" stop-color="#07c3f2"/>
+  </linearGradient>
+  <linearGradient xlink:href="#a" id="c" x1="88.27" x2="93.79" y1="25.47" y2="45.02"/>
+  <path fill="url(#a)" d="M17.44 91.26 4.5 14.56l23.93-9.93 15.28 9.08 14-7.55 29.17 11.2-16.36 83.14z"/>
+  <path fill="url(#b)" d="M100.5 37.01 88.11 6.41 65.63 4.5l-34.7 33.34 9.34 42.97 17.44 12.23 42.79-25.39L90 47.96z"/>
+  <path fill="url(#c)" d="M81.27 32.45 90 47.96l10.5-10.95-7.71-19.06z"/>
+  <path d="M22.5 22.5h60v60h-60z"/>
+  <path fill="#fff" d="M29.98 71.16h22.5v3.75h-22.5zm21.3-41.19L47.93 43.1 44.1 29.97h-3.81L36.45 43.1l-3.34-13.13h-5.25l6.43 22.51h4.22l3.68-13.03 3.64 13.03h4.27l6.42-22.51zm6.18 19.3 2.93-3.51a10.34 10.34 0 0 0 6.74 2.74c2 0 3.26-.8 3.26-2.13v-.06c0-1.26-.78-1.9-4.55-2.87-4.55-1.16-7.48-2.42-7.48-6.9v-.07c0-4.09 3.29-6.8 7.9-6.8a13 13 0 0 1 8.38 2.87l-2.58 3.74a10.54 10.54 0 0 0-5.87-2.22c-1.9 0-2.9.87-2.9 2v.07c0 1.48 1 2 4.87 3 4.58 1.2 7.16 2.84 7.16 6.78v.06c0 4.48-3.42 7-8.29 7a14.34 14.34 0 0 1-9.57-3.61"/>
+</svg>


### PR DESCRIPTION
Webstrom, phpstorm, pycharm, rubytime and fleet logos added

![Screenshot 2023-12-15 at 1 47 45 PM](https://github.com/pheralb/svgl/assets/5209461/4f88b701-c007-4c1c-b3ee-e82e36761b84)


Also, I've added .idea/ folder in the .gitignore file to avoid upload it. 👀 