### PR TITLE
Remove search input hotkey unuse code

### DIFF
--- a/src/components/search.svelte
+++ b/src/components/search.svelte
@@ -5,16 +5,7 @@
   export let clearSearch: () => void;
   import X from 'phosphor-svelte/lib/X';
 
-  let shortcutText: string = '';
   let inputElement;
-
-  if (typeof window !== 'undefined') {
-    if (navigator.platform.toUpperCase().indexOf('MAC') !== -1) {
-      shortcutText = 'command';
-    } else {
-      shortcutText = 'control';
-    }
-  }
 
   function focusInput(node: HTMLElement) {
     const handleKeydown = (event: KeyboardEvent) => {


### PR DESCRIPTION
Remove the unused code for the search input hotkey as part of the improvements in commit a9ea191622603f82903ee7aef0635b6f1a25aaf8.