### PR TITLE
Improve accesibility (in Desktop mode) from 90 to 95

### DIFF
--- a/src/components/navbar.svelte
+++ b/src/components/navbar.svelte
@@ -21,7 +21,8 @@
       name: 'API',
       url: '/api',
       icon: CloudyIcon,
-      external: false
+      external: false,
+      label: "Go to the SVGL's API section"
     },
     {
       name: 'Extensions',
@@ -35,7 +36,7 @@
       url: 'https://github.com/pheralb/svgl#-getting-started',
       icon: ArrowUpRight,
       external: true,
-      label: "Go to the SVGL's getting started section"
+      label: "Submit logo and go to the SVGL's getting started section"
     }
   ];
 </script>
@@ -50,11 +51,13 @@
 >
   <div class="flex items-center justify-between mx-auto">
     <div class="flex items-center space-x-2">
+      <!-- Lighthouse diagnostic in Desktop mode returns an accesibility error respect the 'a' element -->
+      <!-- I don't know why :' -->
       <a href="/" aria-label="Back to the SVGL home page">
         <div class="flex items-center space-x-2 hover:opacity-80 transition-opacity">
           <svelte:component this={Logo} />
           <span class="text-[19px] font-medium tracking-wide hidden md:block">svgl</span>
-          <p class="text-neutral-500 hidden md:block font-mono">v4.0</p>
+          <p class="text-neutral-400 hidden md:block font-mono">v4.0</p>
         </div>
       </a>
     </div>


### PR DESCRIPTION
Improving accesibility issues to make more links accessible: 

Before:
![image](https://github.com/pheralb/svgl/assets/31110242/bb4f2e8d-4636-4388-80c2-a788463b0ac0)


After:
![image](https://github.com/pheralb/svgl/assets/31110242/0f27eb83-22d8-4994-be22-9e6a9e2970e8)
