### PR TITLE
Fix accessibility to 100%

### DIFF
--- a/src/components/navbar.svelte
+++ b/src/components/navbar.svelte
@@ -50,10 +50,8 @@
   )}
 >
   <div class="flex items-center justify-between mx-auto">
-    <div class="flex items-center space-x-2">
-      <!-- Lighthouse diagnostic in Desktop mode returns an accesibility error respect the 'a' element -->
-      <!-- I don't know why :' -->
-      <a href="/" aria-label="Back to the SVGL home page">
+    <div class="flex items-center space-x-2">      
+      <a href="/" aria-label="Go to the SVGL v4.0 home page">
         <div class="flex items-center space-x-2 hover:opacity-80 transition-opacity">
           <svelte:component this={Logo} />
           <span class="text-[19px] font-medium tracking-wide hidden md:block">svgl</span>


### PR DESCRIPTION
## In this pull request, I did the following:

Update `arial-label` to fix accessibility from 95  to 100% on desktop mode

![image](https://github.com/pheralb/svgl/assets/110146573/0e0847d3-6c41-48de-95b5-6099df08ea77)
