### PR TITLE
📦 Added height and width properties for img tags containing svgs

### DIFF
--- a/src/components/svgCard.svelte
+++ b/src/components/svgCard.svelte
@@ -132,6 +132,10 @@
   // Icon Stroke & Size:
   let iconStroke = 1.8;
   let iconSize = 16;
+
+  // Width & Height of <img>:
+  const width = 40;
+  const height = 40;
 </script>
 
 <CardSpotlight>
@@ -146,6 +150,8 @@
         alt={svgInfo.title}
         title={svgInfo.title}
         loading="lazy"
+        {width}
+        {height}
       />
       <img
         class="block dark:hidden mb-4 mt-2 h-10"
@@ -155,6 +161,8 @@
         alt={svgInfo.title}
         title={svgInfo.title}
         loading="lazy"
+        {width}
+        {height}
       />
     {:else}
       <img
@@ -163,6 +171,8 @@
         alt={svgInfo.title}
         title={svgInfo.title}
         loading="lazy"
+        {width}
+        {height}
       />
       <img
         class="block dark:hidden mb-4 mt-2 h-10"
@@ -170,6 +180,8 @@
         alt={svgInfo.title}
         title={svgInfo.title}
         loading="lazy"
+        {width}
+        {height}
       />
     {/if}
     <!-- Title -->


### PR DESCRIPTION
When making the lighthouse I noticed that there was a detail with the width and height of the images.

Before:
![image](https://github.com/pheralb/svgl/assets/83567373/e14c52e1-ddff-4333-b71d-4b7a6485628f)
![image](https://github.com/pheralb/svgl/assets/83567373/a4c77fc4-96a8-442f-9e71-a1165d5b7eb3)

After:
![image](https://github.com/pheralb/svgl/assets/83567373/1cf5a21a-8b93-429e-820c-6f7248dbae2d)
![image](https://github.com/pheralb/svgl/assets/83567373/847872c1-29c6-4d5a-93b5-59292ae470ba)

Take the size based on the class h-10 in the image.
This might fix that little guy, hope it helps!<3