### PR TITLE
Handle non-existant categories and urls

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { redirect } from '@sveltejs/kit';
+
+  redirect(301, '/');
+</script>

--- a/src/routes/directory/[slug]/+page.ts
+++ b/src/routes/directory/[slug]/+page.ts
@@ -21,6 +21,11 @@ export const load = (async ({ params }) => {
     }
   });
 
+  // If SVGs array is empty, category can't exist
+  if (svgsByCategory.length === 0) {
+    return error(404, 'Not found');
+  }
+
   return {
     category: slug as string,
     svgs: svgsByCategory


### PR DESCRIPTION
Handle urls that don't exist:
![image](https://github.com/pheralb/svgl/assets/58951699/d4eac62d-b729-44db-abde-4fe4d655bd55)
This happens when accessing `https://svgl.app/doesnotexist` and because there isn't an +error.svelte present, a default message is shown instead.

![image](https://github.com/pheralb/svgl/assets/58951699/c6b35cbe-9aca-44ae-bebc-0e89cc89843a)
Also, there isn't any validation that the category exists, so when changing the url to an invalid category no logos will appear