### PR TITLE
Error enlace Adobe premiere

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -1530,7 +1530,7 @@ export const svgs: iSVG[] = [
     title: 'Premiere',
     category: 'Design',
     route: '/library/premiere.svg',
-    url: 'https://x.com'
+    url: 'https://www.adobe.com/es/products/premiere'
   },
   {
     title: 'VK',


### PR DESCRIPTION
❗ Error que demuestra: al acceder al link de [Adobe premiere](https://www.adobe.com/es/products/premiere.html) te redigia a el link de Twitter (X).

✅ Cambios: 
 - Se intento solucionar el error cambiando el link desde `src/data/svgl.ts`.
 
Ejemplo del error persistente:

https://github.com/pheralb/svgl/assets/156522801/8326d451-f3ea-4e71-adb9-7d3182bc9b8d

