### PR TITLE
Adjust categories API statistical method

### DIFF
--- a/src/routes/api/categories/+server.ts
+++ b/src/routes/api/categories/+server.ts
@@ -7,9 +7,6 @@ import { ratelimit } from '@/server/redis';
 import { svgs } from '@/data/svgs';
 
 export const GET = async ({ request }: RequestEvent) => {
-  const categories = svgs
-    .map((svg) => svg.category)
-    .filter((category, index, array) => array.indexOf(category) === index);
   const ip = request.headers.get('x-forwarded-for') ?? '';
   const { success, reset } = await ratelimit.limit(ip);
 
@@ -25,14 +22,23 @@ export const GET = async ({ request }: RequestEvent) => {
     });
   }
 
+  const categoryTotals: Record<string, number> = {};
+
+  svgs.forEach((svg) => {
+    if (typeof svg.category === 'string') {
+      categoryTotals[svg.category] = (categoryTotals[svg.category] || 0) + 1;
+    } else if (Array.isArray(svg.category)) {
+      svg.category.forEach((category) => {
+        categoryTotals[category] = (categoryTotals[category] || 0) + 1;
+      });
+    }
+  });
+
+  const categories = Object.entries(categoryTotals).map(([category, total]) => ({
+    category,
+    total
+  }));
+
   // Status 200 | If limit is a number:
-  return json(
-    categories.map((category) => {
-      return {
-        category,
-        total: svgs.filter((svg) => svg.category === category).length
-      };
-    }),
-    { status: 200 }
-  );
+  return json(categories, { status: 200 });
 };


### PR DESCRIPTION
### Description
The original way of category statistics would combine SVGs with composite categories into a new category, such as `{"category":["Hosting","Vercel"],"total":1}`. However, as a category API, it should count the number of SVGs for each independent category. For example, there should be 8 SVGs in the Hosting category, but the response is `{"category":"Hosting","total":7}`, which needs to be merged with another `{"category":["Hosting","Vercel"],"total":1}` to determine that there are 8 SVGs in the Hosting category. This approach is not user-friendly and adds complexity.

And There is currently an issue where all Vercel types are attached to a composite type of svg. Therefore, the API response does not have a separate `{"category": "Vercel"}` item. This may cause some API consumers to overlook and fail to render information related to that category smoothly.

This PR mainly changes the way categories are counted independently. When encountering SVGs with composite categories, it will count the quantities of all associated categories.

### Original Response
```json
[
  { "category": "Software", "total": 131 },
  { "category": "Library", "total": 33 },
  { "category": "Framework", "total": 43 },
  { "category": "Crypto", "total": 19 },
  { "category": "AI", "total": 15 },
  { "category": "CMS", "total": 10 },
  { "category": "Design", "total": 16 },
  { "category": "Music", "total": 3 },
  { "category": "Marketplace", "total": 2 },
  { "category": "Hosting", "total": 7 },
  { "category": "Compiler", "total": 6 },
  { "category": "Social", "total": 24 },
  { "category": ["Library", "Vercel"], "total": 1 },
  { "category": "Entertainment", "total": 9 },
  { "category": "Browser", "total": 11 },
  { "category": "Language", "total": 30 },
  { "category": "Database", "total": 14 },
  { "category": "Education", "total": 7 },
  { "category": "Fintech", "total": 1 },
  { "category": "Community", "total": 3 },
  { "category": ["Software", "CMS"], "total": 1 },
  { "category": ["Hosting", "Vercel"], "total": 1 },
  { "category": ["Framework", "Vercel"], "total": 1 }
]
```

### New Response
```json
[
  { "category": "Software", "total": 132 },
  { "category": "Library", "total": 34 },
  { "category": "Framework", "total": 44 },
  { "category": "Crypto", "total": 19 },
  { "category": "AI", "total": 15 },
  { "category": "CMS", "total": 11 },
  { "category": "Design", "total": 16 },
  { "category": "Music", "total": 3 },
  { "category": "Marketplace", "total": 2 },
  { "category": "Hosting", "total": 8 },
  { "category": "Compiler", "total": 6 },
  { "category": "Social", "total": 24 },
  { "category": "Vercel", "total": 3 },
  { "category": "Entertainment", "total": 9 },
  { "category": "Browser", "total": 11 },
  { "category": "Language", "total": 30 },
  { "category": "Database", "total": 14 },
  { "category": "Education", "total": 7 },
  { "category": "Fintech", "total": 1 },
  { "category": "Community", "total": 3 }
]
```