### PR TITLE
docs: add new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ UPSTASH_REDIS_TOKEN = ""
 
 A list of extensions that use the [svgl API](https://svgl.app/api), created by the community:
 
-|                                                                                                | Extension        | Description                                        | Created by                                | Link                                                                            |
-| ---------------------------------------------------------------------------------------------- | ---------------- | -------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------- |
-| <img src="https://github.com/pheralb/svgl/blob/main/static/library/svgl.svg" height="25" />    | svgls            | A CLI for easily adding SVG icons to your project. | [sujjeee](https://twitter.com/sujjeeee)   | [Github Repository](https://github.com/sujjeee/svgls)                           |
-| <img src="https://github.com/pheralb/svgl/blob/main/static/library/figma.svg" height="25" />   | SVGL for Figma   | Add svgs from svgl to your Figma project.          | [quilljou](https://twitter.com/quillzhou) | [Figma Plugin](https://www.figma.com/community/plugin/1320306989350693206/svgl) |
-| <img src="https://github.com/pheralb/svgl/blob/main/static/library/raycast.svg" height="25" /> | SVGL for Raycast | Search SVG logos via svgl.                         | [1weiho](https://twitter.com/1weiho)      | [Raycast Store](https://www.raycast.com/1weiho/svgl)                            |
+|                                                                                                | Extension        | Description                                        | Created by                                 | Link                                                                                        |
+| ---------------------------------------------------------------------------------------------- | ---------------- | -------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| <img src="https://github.com/pheralb/svgl/blob/main/static/library/svgl.svg" height="25" />    | svgls            | A CLI for easily adding SVG icons to your project. | [sujjeee](https://twitter.com/sujjeeee)    | [Github Repository](https://github.com/sujjeee/svgls)                                       |
+| <img src="https://github.com/pheralb/svgl/blob/main/static/library/figma.svg" height="25" />   | SVGL for Figma   | Add svgs from svgl to your Figma project.          | [quilljou](https://twitter.com/quillzhou)  | [Figma Plugin](https://www.figma.com/community/plugin/1320306989350693206/svgl)             |
+| <img src="https://github.com/pheralb/svgl/blob/main/static/library/raycast.svg" height="25" /> | SVGL for Raycast | Search SVG logos via svgl.                         | [1weiho](https://twitter.com/1weiho)       | [Raycast Store](https://www.raycast.com/1weiho/svgl)                                        |
+| <img src="https://github.com/pheralb/svgl/blob/main/static/library/vscode.svg" height="25" />  | SVGL for VSCode  | SVGL directly in your VSCode.                      | [girlazote](https://twitter.com/girlazote) | [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=EsteveSegura.svgl) |
 
 ## ✌️ Contributing
 


### PR DESCRIPTION
## Content
Adding a new integration in the documentation section referring to a VSCode extension:

- [Github](https://github.com/EsteveSegura/svgl-vscode)
- [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=EsteveSegura.svgl)

Extension demo.

https://github.com/pheralb/svgl/assets/10067827/00c76855-aa44-450b-a746-0c054da3d32a

## Following updates 
- Caching svgs when user first opens the vscode (avoid hitting all the time svgl apis)
- Adding extra metadata and demos