### PR TITLE
Fix filter SVGs by category doesn't handle multiple categories's SVGs

### DIFF
--- a/src/routes/api/svgs/+server.ts
+++ b/src/routes/api/svgs/+server.ts
@@ -58,9 +58,8 @@ export const GET = async ({ url, request }: RequestEvent) => {
   const category = getCategoryParams;
 
   if (category) {
+    const targetCategory = category.charAt(0).toUpperCase() + category.slice(1);
     const categorySvgs = fullRouteSvgsData.filter((svg) => {
-      const targetCategory = category.charAt(0).toUpperCase() + category.slice(1);
-
       if (typeof svg.category === 'string') {
         return svg.category === targetCategory;
       }

--- a/src/routes/api/svgs/+server.ts
+++ b/src/routes/api/svgs/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestEvent } from './$types';
 import type { iSVG } from '@/types/svg';
+import type { tCategory } from '@/types/categories';
 
 import { error, json } from '@sveltejs/kit';
 import { ratelimit } from '@/server/redis';
@@ -58,7 +59,17 @@ export const GET = async ({ url, request }: RequestEvent) => {
 
   if (category) {
     const categorySvgs = fullRouteSvgsData.filter((svg) => {
-      return svg.category === category.charAt(0).toUpperCase() + category.slice(1);
+      const targetCategory = category.charAt(0).toUpperCase() + category.slice(1);
+
+      if (typeof svg.category === 'string') {
+        return svg.category === targetCategory;
+      }
+
+      if (Array.isArray(svg.category)) {
+        return svg.category.includes(targetCategory as tCategory);
+      }
+
+      return false;
     });
 
     // Error 400 | If category does not exist:


### PR DESCRIPTION
### Original

Request:

`GET` https://svgl.vercel.app/api/svgs?category=vercel

Response:

```
Category does not exist.
```

### After fix

Request:

`GET` https://svgl.vercel.app/api/svgs?category=vercel

Response:

```json
[
  {
    "id": 35,
    "title": "Turborepo",
    "category": ["Library", "Vercel"],
    "route": "http://localhost:5173/library/turborepo.svg",
    "url": "https://turborepo.org/"
  },
  {
    "id": 380,
    "title": "Vercel",
    "category": ["Hosting", "Vercel"],
    "route": {
      "light": "http://localhost:5173/library/vercel.svg",
      "dark": "http://localhost:5173/library/vercel_dark.svg"
    },
    "wordmark": {
      "light": "/library/vercel_wordmark.svg",
      "dark": "/library/vercel_wordmark_dark.svg"
    },
    "url": "https://vercel.com/"
  },
  {
    "id": 381,
    "title": "Next.js",
    "category": ["Framework", "Vercel"],
    "route": "http://localhost:5173/library/nextjs_icon_dark.svg",
    "wordmark": {
      "light": "/library/nextjs_logo_light.svg",
      "dark": "/library/nextjs_logo_dark.svg"
    },
    "url": "https://nextjs.org/"
  }
]
```