### PR TITLE
fix: modify span to h1 and add canonical links

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -32,7 +32,6 @@
     ></script>
 
     <!-- Title -->
-    <title>A beautiful library with SVG logos - Svgl</title>
     %sveltekit.head%
   </head>
   <body

--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/images/logo.svg" />
-
+    <link rel="canonical" href="https://svgl.app/" />
     <!-- OG -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="svgl" />

--- a/src/components/navbar.svelte
+++ b/src/components/navbar.svelte
@@ -48,7 +48,7 @@
       <a href="/" aria-label="Go to the SVGL v4.1 home page">
         <div class="flex items-center space-x-2 opacity-100 hover:opacity-80 transition-opacity">
           <svelte:component this={Logo} />
-          <span class="text-[19px] font-medium tracking-wide hidden md:block">svgl</span>
+          <h1 class="text-[19px] font-medium tracking-wide hidden md:block">svgl</h1>
           <p class="text-neutral-400 hidden md:block font-mono">v4.2</p>
         </div>
       </a>

--- a/src/routes/directory/[slug]/+page.svelte
+++ b/src/routes/directory/[slug]/+page.svelte
@@ -47,6 +47,7 @@
 
 <svelte:head>
   <title>{category} logos - Svgl</title>
+  <link rel="canonical" href="https://svgl.app/{category}/" />
 </svelte:head>
 
 <Container>


### PR DESCRIPTION
Hola Pheralb !! 
Usando la extensión que recomendó Midu Metaexplorer, que te parece estas soluciones:
Produ:
![image](https://github.com/pheralb/svgl/assets/139919492/4d2899d0-c443-4c78-881a-55b0f83343fe)
Local:
![image](https://github.com/pheralb/svgl/assets/139919492/1d130b5d-0b6a-405f-8e74-0c1d320146a4)
![image](https://github.com/pheralb/svgl/assets/139919492/2076fd76-b160-4426-b00c-83ae0f1ef050)

- He quitado el title en App.html
- He agregado link canonical a App.html, y src/routes/directory/[slug]+page.svelte

Es la primera vez que trabajo con svelte, si hay errores. Ignora la PR porfi.

Saludos!!


