### PR TITLE
Fix incorrect category for svelte

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -75,7 +75,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Svelte',
-    category: 'Library',
+    category: 'Framework',
     route: '/library/svelte.svg',
     url: 'https://svelte.dev/'
   },


### PR DESCRIPTION
Svelte is a framework, not a library