### PR TITLE
Fix: cancel the loading state after the react component fetch fails

### DIFF
--- a/src/components/copySvg.svelte
+++ b/src/components/copySvg.svelte
@@ -113,6 +113,7 @@
         description: `${error ?? ''}`,
         duration: 5000
       });
+      isLoading = false;
       return;
     }
 


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/08f0ccb0-ec27-4345-abe2-d4973e63ff6f

## After

https://github.com/user-attachments/assets/f2aa37d7-350f-434c-9e2e-416f8329bb49
