### PR TITLE
Add cross-platform keyboard shortcut

### DIFF
--- a/src/components/search.svelte
+++ b/src/components/search.svelte
@@ -70,7 +70,7 @@
         </button>
       </div>
     {:else}
-      <div class="absolute inset-y-0 right-0 flex items-center pr-4 text-neutral-500">
+      <div class="absolute inset-y-0 right-0 flex items-center pointer-events-none  pr-4 text-neutral-500">
         {#if isMac}
           <Command size={16} />
         {:else}
@@ -78,7 +78,7 @@
         {/if}
         <kbd
           class={isMac
-            ? ''
+            ? 'ml-1'
             : 'ml-1 rounded border border-neutral-500 px-1 py-0.5 text-xs shadow-sm'}>K</kbd
         >
       </div>

--- a/src/components/search.svelte
+++ b/src/components/search.svelte
@@ -72,7 +72,7 @@
     {:else}
       <div class="absolute inset-y-0 right-0 flex items-center pr-4 text-neutral-500">
         {#if isMac}
-          <Command size={18} />
+          <Command size={16} />
         {:else}
           <kbd class="rounded border border-neutral-500 px-1 py-0.5 text-xs shadow-sm">Ctrl</kbd>
         {/if}

--- a/src/components/search.svelte
+++ b/src/components/search.svelte
@@ -6,9 +6,13 @@
   export let placeholder: string = 'Search...';
   export let clearSearch: () => void;
   import { X } from 'lucide-svelte';
+  import { onMount } from 'svelte';
 
   let inputElement;
-
+  let isMac = true;
+  onMount(() => {
+    isMac = /(Macintosh|iPhone|iPod|iPad)/i.test(navigator.userAgent);
+  });
   function focusInput(node: HTMLElement) {
     const handleKeydown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
@@ -67,10 +71,16 @@
       </div>
     {:else}
       <div class="absolute inset-y-0 right-0 flex items-center pr-4 text-neutral-500">
-        <div class="flex h-full items-center pointer-events-none gap-x-1 font-mono">
-          <Command size={16} />
-          <span>K</span>
-        </div>
+        {#if isMac}
+          <Command size={18} />
+        {:else}
+          <kbd class="rounded border border-neutral-500 px-1 py-0.5 text-xs shadow-sm">Ctrl</kbd>
+        {/if}
+        <kbd
+          class={isMac
+            ? ''
+            : 'ml-1 rounded border border-neutral-500 px-1 py-0.5 text-xs shadow-sm'}>K</kbd
+        >
       </div>
     {/if}
   </div>


### PR DESCRIPTION
Add check to display "Ctrl" instead of "⌘" for non-Mac users and use ```<kbd>``` element



Before on Windows/Linux:

![Screenshot from 2024-11-05 16-44-06](https://github.com/user-attachments/assets/04ec4af8-e614-4d59-a589-5ca165c5ce14)

After: 

![Screenshot from 2024-11-05 16-32-02](https://github.com/user-attachments/assets/73a418e6-0fe5-4f79-b20d-d083aeb3c6e0)

For Mac users it will stay the same as before