### PR TITLE
Adjustments to Shadcn's icons.

### DIFF
--- a/static/library/shadcn-ui.svg
+++ b/static/library/shadcn-ui.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="currentColor" stroke-width="25" d="M208 128l-80 80M192 40L40 192"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="currentColor" stroke-width="25" stroke-linecap="round" d="M208 128l-80 80M192 40L40 192"/></svg>

--- a/static/library/shadcn-ui.svg
+++ b/static/library/shadcn-ui.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="currentColor" d="M208 128l-80 80M192 40L40 192"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="currentColor" stroke-width="25" d="M208 128l-80 80M192 40L40 192"/></svg>

--- a/static/library/shadcn-ui_dark.svg
+++ b/static/library/shadcn-ui_dark.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="#fff" d="M208 128l-80 80M192 40L40 192"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="#fff" stroke-width="25" d="M208 128l-80 80M192 40L40 192"/></svg>

--- a/static/library/shadcn-ui_dark.svg
+++ b/static/library/shadcn-ui_dark.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="#fff" stroke-width="25" d="M208 128l-80 80M192 40L40 192"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><path fill="none" d="M0 0h256v256H0z"/><path fill="none" stroke="#fff" stroke-width="25" stroke-linecap="round" d="M208 128l-80 80M192 40L40 192"/></svg>


### PR DESCRIPTION
Added some adjustments to the **"stroke-width"** and the **"stroke-linecap"** to make the icon look more like the original. It also improves readability.

Before:
![image](https://github.com/user-attachments/assets/6dfe0452-abc4-44da-8483-5985760f4e8e)

After:
![image](https://github.com/user-attachments/assets/522abce8-3be5-4cb4-9dda-722b3520505e)