### PR TITLE
fix: typo for "DuckDuckGo"

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -1409,7 +1409,7 @@ export const svgs: iSVG[] = [
     url: 'https://webkit.org/'
   },
   {
-    title: 'DuckDucgGo',
+    title: 'DuckDuckGo',
     category: ['Software', 'Browser'],
     route: '/library/duckduckgo.svg',
     wordmark: '/library/duckduckgo-wordmark.svg',


### PR DESCRIPTION
Fix typo for DuckDuckGo.
Close #499