### PR TITLE
Update Google product's SVG categories to include relevant tags

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -2351,7 +2351,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Google Idx',
-    category: 'Software',
+    category: ['Software', 'Google'],
     route: '/library/google-idx.svg',
     url: 'https://idx.dev/'
   },
@@ -2412,7 +2412,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Bitwarden',
-    category: 'Software',
+    category: ['Software', 'Authentication'],
     route: '/library/bitwarden.svg',
     url: 'https://bitwarden.com/'
   },
@@ -2463,7 +2463,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Google PaLM',
-    category: 'AI',
+    category: ['AI', 'Google'],
     route: '/library/google-palm.svg',
     url: 'https://ai.google/discover/palm2/'
   },
@@ -2906,7 +2906,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Firebase',
-    category: 'Hosting',
+    category: ['Hosting', 'Google'],
     route: '/library/firebase.svg',
     wordmark: '/library/firebase-wordmark.svg',
     url: 'https://firebase.google.com/'


### PR DESCRIPTION
## 📝 About your SVG: N/A

- **Title**: Added 'Google' category to missing google products SVG
- **Category**: Google
- **Website URL**: 
- **Description**: This solves: 
- https://github.com/pheralb/svgl/issues/522,
- https://github.com/pheralb/svgl/issues/521
- Also added Firebase to it

Also

## 📷 Screenshots:

Before:
![image](https://github.com/user-attachments/assets/210502e5-2385-482d-9ff1-50aff231fdae)

After:
![image](https://github.com/user-attachments/assets/8e2acb7b-ef81-485e-aec9-fefcbf312843)


## ✅ Checklist

- [x] I have permission to use this logo.
- [x] The ``.svg`` file is optimized for web use.
- [x] The ``.svg`` size is less than **20kb**.
