### PR TITLE
Update category names from 'void(0)' to 'VoidZero' in SVG

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -2953,25 +2953,25 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Vite',
-    category: ['Devtool', 'void(0)'],
+    category: ['Devtool', 'VoidZero'],
     route: '/library/vitejs.svg',
     url: 'https://vitejs.dev'
   },
   {
     title: 'Vitest',
-    category: ['Framework', 'void(0)'],
+    category: ['Framework', 'VoidZero'],
     route: '/library/vitest.svg',
     url: 'https://vitest.dev/'
   },
   {
     title: 'Oxc',
-    category: ['Devtool', 'void(0)'],
+    category: ['Devtool', 'VoidZero'],
     route: '/library/oxc.svg',
     url: 'https://oxc.rs/'
   },
   {
     title: 'Rolldown',
-    category: ['Compiler', 'void(0)'],
+    category: ['Compiler', 'VoidZero'],
     route: '/library/rolldown.svg',
     url: 'https://rolldown.rs/'
   },

--- a/src/types/categories.ts
+++ b/src/types/categories.ts
@@ -25,7 +25,7 @@ export type tCategory =
   | 'Vercel'
   | 'Google'
   | 'Payment'
-  | 'void(0)'
+  | 'VoidZero'
   | 'Authentication'
   | 'IoT'
   | 'Home Automation'


### PR DESCRIPTION
## 📝 About your SVG:

- **Title**: Update void(0) to VoidZero
- **Category**: void(0)
- **Website URL**:
- **Description**: As @aryanprince says on https://github.com/pheralb/svgl/issues/490: `The "Vercel" category only displays their company name as text and not their logomark/wordmark logo (the triangle logo), but the VoidZero category on svgl.app is it's wordmark (as text).`, and also their footer and page title is "VoidZero"

## 📷 Screenshots:

![image](https://github.com/user-attachments/assets/6070b4cd-74d3-441d-a366-e6ced0c28e2c)

Company name on his footer:
<img width="1117" alt="Screenshot 2025-01-27 at 10 12 24 AM" src="https://github.com/user-attachments/assets/3c8d764d-c71e-442f-9713-69f8c3d0d566" />


## ✅ Checklist

- [x] I have permission to use this logo.
- [x] The ``.svg`` file is optimized for web use.
- [x] The ``.svg`` size is less than **20kb**.
