### PR TITLE
♻️ Renamed "React" to "React.js" for Consistency

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -164,7 +164,7 @@ export const svgs: iSVG[] = [
     url: 'https://preactjs.com/'
   },
   {
-    title: 'React',
+    title: 'React.js',
     category: 'Library',
     route: {
       light: '/library/react_light.svg',


### PR DESCRIPTION
 - Standardized naming by updating "React" to "React.js" for clarity.
 - Helps preserve the intended name and avoids ambiguity.
 - Aligns with official naming conventions.