### PR TITLE
fix: correct route for Firebase Studio SVG asset

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -4,7 +4,7 @@ export const svgs: iSVG[] = [
   {
     title: 'Firebase Studio',
     category: ['AI', 'Google'],
-    route: '/library/firebase-studio.svg',
+    route: '/library/firebasestudio.svg',
     url: 'https://firebase.studio/'
   },
   {


### PR DESCRIPTION
I made a mistake with the SVG path in a previous commit. This PR corrects the route to properly load the Firebase Studio icon.