### PR TITLE
chore: add payment tag to polar

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -3212,7 +3212,7 @@ export const svgs: iSVG[] = [
   },
   {
     title: 'Polar',
-    category: 'Software',
+    category: ['Software', 'Payment'],
     route: {
       light: '/library/polar-sh_light.svg',
       dark: '/library/polar-sh_dark.svg'


### PR DESCRIPTION
Polar is a payment infrastructure company so it seemed appropriate to tag them `Payment`

(Deleted PR template because I am not introducing new logos, just updating tags)