### PR TITLE
Add testing comment for GitHub host changes

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,3 +23,5 @@ const config = {
 };
 
 export default config;
+
+//TESTING for changes on my GitHub HOST


### PR DESCRIPTION
Esta es una nueva implementación de comentarios en código solo como versión de prueba

ANTES:
<img width="952" height="115" alt="image" src="https://github.com/user-attachments/assets/67646b4c-bf4d-471a-becf-4fb76a70edf8" />



DESPUES:

<img width="508" height="379" alt="image" src="https://github.com/user-attachments/assets/88947981-d1f2-4245-8b11-b7a432cc4b87" />
