### PR TITLE
📦 Add Kibo UI light + dark logos

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -3814,5 +3814,14 @@ export const svgs: iSVG[] = [
     category: 'Library',
     route: '/library/unjs.svg',
     url: 'https://unjs.io/'
+  },
+  {
+    title: 'Kibo UI',
+    category: 'Library',
+    route: {
+      light: '/library/kibo-ui-light.svg',
+      dark: '/library/kibo-ui-dark.svg'
+    },
+    url: 'https://kibo-ui.com/'
   }
 ];

--- a/static/library/kibo-ui-dark.svg
+++ b/static/library/kibo-ui-dark.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="116" viewBox="0 0 117 116" width="117" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m29.8378 0h87.0002v29 58l-29.0002 29v-87h-87.000031zm-29.000031 95.7389v-37.7389h37.738831zm58.000031 20.2611h-37.249l37.249-37.2488z" fill="#fff" fill-rule="evenodd"/></svg>

--- a/static/library/kibo-ui-light.svg
+++ b/static/library/kibo-ui-light.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="116" viewBox="0 0 117 116" width="117" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m29.8378 0h87.0002v29 58l-29.0002 29v-87h-87.000031zm-29.000031 95.7389v-37.7389h37.738831zm58.000031 20.2611h-37.249l37.249-37.2488z" fill="#000" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
## 📝 About your SVG:

- **Title**: Kibo UI
- **Category**: Library
- **Website URL**: https://kibo-ui.com/
- **Description**: A custom registry of composable, accessible and open source components designed for use with shadcn/ui.

## 📷 Screenshots:

**Light:**

![kibo-ui-light](https://github.com/user-attachments/assets/a6635763-122b-48c9-9bd6-c8a7a7a6c293)

**Dark:**

![kibo-ui-dark](https://github.com/user-attachments/assets/b7615518-afce-43d7-9e98-d26f1872c2c3)

## ✅ Checklist

- [x] I have permission to use this logo.
- [x] The ``.svg`` file is optimized for web use.
- [x] The ``.svg`` size is less than **20kb**.
