### PR TITLE
🛠️Adds native macOS shortcut support for opening the search menu

### DIFF
--- a/src/components/search.svelte
+++ b/src/components/search.svelte
@@ -29,7 +29,7 @@
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
-    if (event.ctrlKey && event.key === "k") {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
       event.preventDefault();
       inputElement?.focus();
     }


### PR DESCRIPTION
Adds support for the ⌘K shortcut on macOS to open the search menu. 🙌


## 📷 Screenshots:

<img width="829" height="105" alt="Screenshot 2025-09-30 at 11 47 10 AM" src="https://github.com/user-attachments/assets/9cd8e572-db58-48cb-9295-b4149b23ac44" />
