### PR TITLE
🛠️ Fix pass missing optimize parameter to prevent forced optimization

### DIFF
--- a/src/components/svgs/copySvg.svelte
+++ b/src/components/svgs/copySvg.svelte
@@ -162,7 +162,12 @@
       content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
     }
 
-    const dataComponent = { code: content, typescript: tsx, name: title };
+    const dataComponent = {
+      code: content,
+      typescript: tsx,
+      name: title,
+      optimize,
+    };
     const { data, error } = await getReactCode(dataComponent);
 
     if (error || !data) {


### PR DESCRIPTION
The `optimize` parameter was missing from the API request, causing 
`body.optimize !== false` (svgr/+server.ts:L18) to always evaluate to `true`.
https://github.com/pheralb/svgl/blob/224d4fbc259213dbd385eeeb716b3ccdee4665ae/src/routes/api/svgs/svgr/%2Bserver.ts#L18
`optimize` missing → `body.optimize` is `undefined` → `undefined !== false` evaluates to `true`

This resulted in SVG optimization always running and removing gradients 
even when users disabled it.