### PR TITLE
feat: add databuddy's logo

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -2123,6 +2123,12 @@ export const svgs: iSVG[] = [
     url: "https://www.datadoghq.com/",
   },
   {
+    title:"Databuddy",
+    category:"Analytics",
+    route: "/library/databuddy.svg",
+    url: "https://www.databuddy.cc/",
+  },
+  {
     title: "Tron",
     category: "Crypto",
     route: "/library/tron.svg",

--- a/static/library/databuddy.svg
+++ b/static/library/databuddy.svg
@@ -1,0 +1,1 @@
+<svg width="512" height="512" viewBox="0 0 8 8" shape-rendering="crispEdges" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h8v8H0z"/><path fill="#fff" d="M1 1h1v6H1zm1 0h4v1H2zm4 1h1v1H6zm0 1h1v1H6zm0 1h1v1H6zm0 1h1v1H6zM2 6h4v1H2zm1-3h1v1H3zm1 1h1v1H4z"/></svg>


### PR DESCRIPTION
## 📝 About your SVG:

- **Title**: Databuddy
- **Category**: Analytics
- **Website URL**: https://databuddy.cc
- **Description**: Privacy first OSS analytics

## 📷 Screenshots:
<img width="503" height="504" alt="CleanShot 2026-01-17 at 18 43 00" src="https://github.com/user-attachments/assets/6102951b-5515-40ae-ad65-833d9836202d" />

## ✅ Checklist

- [x] I have permission to use this logo.
- [x] The ``.svg`` file is optimized for web use.
- [x] The ``.svg`` size is less than **20kb**.
