### PR TITLE
fix: convert stop-opacity to stopOpacity in react output

### DIFF
--- a/src/utils/parseReactSvgContent.ts
+++ b/src/utils/parseReactSvgContent.ts
@@ -21,6 +21,7 @@ const Attributes: Record<string, string> = {
   "text-anchor": "textAnchor",
   "xml:space": "xmlSpace",
   "stop-color": "stopColor",
+  "stop-opacity": "stopOpacity",
   "color-interpolation-filters": "colorInterpolationFilters",
   "xlink:href": "xlinkHref",
 };


### PR DESCRIPTION
### context
bug showed up when copying the instagram icon as react

### before (original react output)

```html
<stop offset="0" stopColor="#fc0"/>
<stop offset=".567" stopColor="#fe4a05"/>
<stop offset="1" stopColor="#fe0657" stop-opacity="0"/>
```

### after (react output post fix)

```html
<stop offset="0" stopColor="#fc0"/>
<stop offset=".567" stopColor="#fe4a05"/>
<stop offset="1" stopColor="#fe0657" stopOpacity="0"/>
```