### PR TITLE
Add OpenHook logo

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -4555,6 +4555,12 @@ export const svgs: iSVG[] = [
     url: "https://openclaw.ai/",
   },
   {
+    title: "OpenHook",
+    category: ["Devtool", "Platform"],
+    route: "/library/openhook.svg",
+    url: "https://openhook.dev/",
+  },
+  {
     title: "Dracula",
     category: ["Themes"],
     route: {

--- a/static/library/openhook.svg
+++ b/static/library/openhook.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect x="10" y="10" width="80" height="80" stroke="currentColor" stroke-width="3"/>
+  <path d="M30 28V55C30 66.046 38.954 75 50 75C61.046 75 70 66.046 70 55V48" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+  <path d="M40 38V52C40 57.523 44.477 62 50 62C55.523 62 60 57.523 60 52V50" stroke="currentColor" stroke-width="6" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add the OpenHook logo SVG to the library
- register OpenHook in `src/data/svgs.ts`

## Notes
- category: `Devtool`, `Platform`
- website: https://openhook.dev/
