### PR TITLE
Add Runframe logo

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -4651,4 +4651,10 @@ export const svgs: iSVG[] = [
     },
     url: "https://www.cerebras.ai/",
   },
+  {
+    title: "Runframe",
+    category: ["Software", "DevOps", "Tools"],
+    route: "/library/runframe.svg",
+    url: "https://runframe.io",
+  },
 ];

--- a/static/library/runframe.svg
+++ b/static/library/runframe.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" fill="#000000" rx="64"/>
+  <g transform="translate(32, 32) skewX(-10) scale(4.5)">
+    <path d="M 24 28 L 24 72 L 36.5 72 L 36.5 47 L 54 47 L 54 28 L 36.5 28 Z" fill="#ffffff"/>
+    <path d="M 96 28 L 96 72 L 83.5 72 L 83.5 47 L 66 47 L 66 28 L 83.5 28 Z" fill="#ffffff"/>
+  </g>
+</svg>


### PR DESCRIPTION
## 📝 About your SVG:

- __Title__: Runframe
- __Category__: "Software", "DevOps", "Tools"
- __Website URL__: https://runframe.io
- __Description__: Runframe is an incident management and on-call scheduling platform for engineering teams.

## 📷 Screenshots:
<img width="511" height="228" alt="Screenshot 2026-04-14 at 04 28 11" src="https://github.com/user-attachments/assets/30e0599f-5221-4868-bf47-dcfe96ac85d1" />


## ✅ Checklist

- I have permission to use this logo.
- The `.svg` file is optimized for web use.
- The `.svg` size is less than __20kb__.