### PR TITLE
fix: align warning message content

### DIFF
--- a/src/components/warningMessage.svelte
+++ b/src/components/warningMessage.svelte
@@ -10,7 +10,7 @@
 {#if !$warningStore}
   <div
     class={cn(
-      "flex w-full flex-col items-center justify-between space-y-2 px-3 py-4 text-sm md:flex-row md:space-y-0 md:space-x-2 md:py-2",
+      "flex w-full flex-col items-center justify-between space-y-2 px-4 py-4 text-sm md:flex-row md:space-y-0 md:space-x-2 md:py-2",
       "bg-white dark:bg-neutral-900",
       "border-b border-neutral-200 dark:border-neutral-800",
     )}


### PR DESCRIPTION
## 📝 About your SVG:

- **Title**: N/A - UI alignment cleanup
- **Category**: N/A
- **Website URL**: https://svgl.app
- **Description**: Aligns the warning notice content with the search results header so the notice reads as part of the same panel structure instead of starting a few pixels off-grid.

This makes the home page UI cleaner and easier to scan: the warning icon now lines up with the logo count icon, and the warning copy starts on the same text column as the logo count text.

## 📷 Screenshots:

Before:

![Before warning alignment](https://raw.githubusercontent.com/Hsiii/svgl/codex/pr-assets-align-warning/.github/pr-assets/align-warning-message/before.png)

After:

![After warning alignment](https://raw.githubusercontent.com/Hsiii/svgl/codex/pr-assets-align-warning/.github/pr-assets/align-warning-message/after.png)

## ✅ Checklist

- [x] I have permission to use this logo. N/A - no logo asset changes.
- [x] The ``.svg`` file is optimized for web use. N/A - no SVG changes.
- [x] The ``.svg`` size is less than **20kb**. N/A - no SVG changes.
