### PR TITLE
fix: use title as fallback for aria-label on links

### DIFF
--- a/src/components/ui/links/external-link.svelte
+++ b/src/components/ui/links/external-link.svelte
@@ -9,7 +9,7 @@
   {href}
   {title}
   target="_blank"
-  aria-label={label}
+  aria-label={label ?? title}
   rel="noopener noreferrer"
   class={cn(className)}
 >

--- a/src/components/ui/links/internal-link.svelte
+++ b/src/components/ui/links/internal-link.svelte
@@ -19,7 +19,7 @@
 <a
   {href}
   {title}
-  aria-label={label}
+  aria-label={label ?? title}
   class={cn(className)}
   data-sveltekit-preload-data={preloadData ? "" : "off"}
 >


### PR DESCRIPTION
## Summary
- Use ‘title’ as fallback for ‘aria-label’ on internal and external links
- Improves accessibility for icon-only links
## Test plan
- [x] Lighthouse accessibility score: 100
