### PR TITLE
fix: resolve 4 bugs in SVG download and copy functionality

### DIFF
--- a/src/components/svgs/copySvg.svelte
+++ b/src/components/svgs/copySvg.svelte
@@ -147,45 +147,51 @@
 
   // Convert SVG as React component:
   const convertSvgReactComponent = async (tsx: boolean) => {
-    const svgUrlToCopy = getSvgUrl();
-    optionsOpen = false;
+    try {
+      const svgUrlToCopy = getSvgUrl();
+      optionsOpen = false;
 
-    isLoading = true;
+      isLoading = true;
 
-    const title = svgInfo.title.split(" ").join("");
-    let content = await getSource({
-      url: svgUrlToCopy,
-      optimize,
-    });
-
-    if (svgUrlToCopy) {
-      content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
-    }
-
-    const dataComponent = {
-      code: content,
-      typescript: tsx,
-      name: title,
-      optimize,
-    };
-    const { data, error } = await getReactCode(dataComponent);
-
-    if (error || !data) {
-      toast.error("Failed to fetch React component", {
-        description: `${error ?? ""}`,
-        duration: 5000,
+      const title = svgInfo.title.split(" ").join("");
+      let content = await getSource({
+        url: svgUrlToCopy,
+        optimize,
       });
+
+      if (svgUrlToCopy) {
+        content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
+      }
+
+      const dataComponent = {
+        code: content,
+        typescript: tsx,
+        name: title,
+        optimize,
+      };
+      const { data, error } = await getReactCode(dataComponent);
+
+      if (error || !data) {
+        toast.error("Failed to fetch React component", {
+          description: `${error ?? ""}`,
+          duration: 5000,
+        });
+        isLoading = false;
+        return;
+      }
+
+      await clipboard(data);
+
+      toast.success(`Copied as React ${tsx ? "TSX" : "JSX"} component`, {
+        description: `${svgInfo.title} - ${svgInfo.category}`,
+      });
+
       isLoading = false;
-      return;
+    } catch (err) {
+      console.error("Error converting to React component:", err);
+      toast.error("Failed to convert React component");
+      isLoading = false;
     }
-
-    await clipboard(data);
-
-    toast.success(`Copied as React ${tsx ? "TSX" : "JSX"} component`, {
-      description: `${svgInfo.title} - ${svgInfo.category}`,
-    });
-
-    isLoading = false;
   };
 
   // Copy SVG as Vue Component:
@@ -266,114 +272,132 @@
 
   // Copy SVG as Standalone Angular component:
   const convertSvgAngularComponent = async () => {
-    isLoading = true;
-    optionsOpen = false;
+    try {
+      isLoading = true;
+      optionsOpen = false;
 
-    const title = svgInfo.title.split(" ").join("");
-    const svgUrlToCopy = getSvgUrl();
-    let content = await getSource({
-      url: svgUrlToCopy,
-      optimize,
-    });
-
-    if (svgUrlToCopy) {
-      content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
-    }
-
-    if (!content) {
-      toast.error("Failed to fetch the SVG content", {
-        duration: 5000,
+      const title = svgInfo.title.split(" ").join("");
+      const svgUrlToCopy = getSvgUrl();
+      let content = await getSource({
+        url: svgUrlToCopy,
+        optimize,
       });
+
+      if (svgUrlToCopy) {
+        content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
+      }
+
+      if (!content) {
+        toast.error("Failed to fetch the SVG content", {
+          duration: 5000,
+        });
+        isLoading = false;
+        return;
+      }
+
+      const angularComponent = getAngularCode({
+        componentName: title,
+        svgContent: content,
+      });
+
+      await clipboard(angularComponent);
+
+      toast.success(`Copied as Standalone Angular component`, {
+        description: `${svgInfo.title} - ${svgInfo.category}`,
+      });
+
       isLoading = false;
-      return;
+    } catch (err) {
+      console.error("Error converting to Angular component:", err);
+      toast.error("Failed to convert Angular component");
+      isLoading = false;
     }
-
-    const angularComponent = getAngularCode({
-      componentName: title,
-      svgContent: content,
-    });
-
-    await clipboard(angularComponent);
-
-    toast.success(`Copied as Standalone Angular component`, {
-      description: `${svgInfo.title} - ${svgInfo.category}`,
-    });
-
-    isLoading = false;
   };
 
   // Copy SVG as Web Component:
   const convertSvgWebComponent = async () => {
-    isLoading = true;
-    optionsOpen = false;
+    try {
+      isLoading = true;
+      optionsOpen = false;
 
-    const title = svgInfo.title.split(" ").join("");
-    const svgUrlToCopy = getSvgUrl();
-    let content = await getSource({
-      url: svgUrlToCopy,
-      optimize,
-    });
-
-    if (svgUrlToCopy) {
-      content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
-    }
-
-    if (!content) {
-      toast.error("Failed to fetch the SVG content", {
-        duration: 5000,
+      const title = svgInfo.title.split(" ").join("");
+      const svgUrlToCopy = getSvgUrl();
+      let content = await getSource({
+        url: svgUrlToCopy,
+        optimize,
       });
+
+      if (svgUrlToCopy) {
+        content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
+      }
+
+      if (!content) {
+        toast.error("Failed to fetch the SVG content", {
+          duration: 5000,
+        });
+        isLoading = false;
+        return;
+      }
+
+      const webComponentCode = getWebComponent({
+        name: title,
+        content: content,
+      });
+
+      await clipboard(webComponentCode);
+
+      toast.success(`Copied as Web Component`, {
+        description: `${svgInfo.title} - ${svgInfo.category}`,
+      });
+
       isLoading = false;
-      return;
+    } catch (err) {
+      console.error("Error converting to Web Component:", err);
+      toast.error("Failed to convert Web Component");
+      isLoading = false;
     }
-
-    const webComponentCode = getWebComponent({
-      name: title,
-      content: content,
-    });
-
-    await clipboard(webComponentCode);
-
-    toast.success(`Copied as Web Component`, {
-      description: `${svgInfo.title} - ${svgInfo.category}`,
-    });
-
-    isLoading = false;
   };
 
   // Copy SVG as Astro component:
   const convertSvgAstroComponent = async () => {
-    isLoading = true;
-    optionsOpen = false;
+    try {
+      isLoading = true;
+      optionsOpen = false;
 
-    const svgUrlToCopy = getSvgUrl();
-    let content = await getSource({
-      url: svgUrlToCopy,
-      optimize,
-    });
-
-    if (svgUrlToCopy) {
-      content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
-    }
-
-    if (!content) {
-      toast.error("Failed to fetch the SVG content", {
-        duration: 5000,
+      const svgUrlToCopy = getSvgUrl();
+      let content = await getSource({
+        url: svgUrlToCopy,
+        optimize,
       });
+
+      if (svgUrlToCopy) {
+        content = prefixSvgIds(content, getPrefixFromSvgUrl(svgUrlToCopy));
+      }
+
+      if (!content) {
+        toast.error("Failed to fetch the SVG content", {
+          duration: 5000,
+        });
+        isLoading = false;
+        return;
+      }
+
+      const astroComponentCode = getAstroCode({
+        svgContent: content,
+      });
+
+      await clipboard(astroComponentCode);
+
+      toast.success(`Copied as Astro Component`, {
+        description: `${svgInfo.title} - ${svgInfo.category}`,
+      });
+
       isLoading = false;
-      return;
+    } catch (err) {
+      console.error("Error converting to Astro Component:", err);
+      toast.error("Failed to convert Astro Component");
+      isLoading = false;
     }
-
-    const astroComponentCode = getAstroCode({
-      svgContent: content,
-    });
-
-    await clipboard(astroComponentCode);
-
-    toast.success(`Copied as Astro Component`, {
-      description: `${svgInfo.title} - ${svgInfo.category}`,
-    });
-
-    isLoading = false;
   };
 </script>
 

--- a/src/components/svgs/downloadSvg.svelte
+++ b/src/components/svgs/downloadSvg.svelte
@@ -122,11 +122,7 @@
       <div class={cn("flex flex-col gap-4 md:flex-row")}>
         {#if typeof svgInfo.route === "string"}
           <div class={cardDownloadStyles}>
-            <img
-              src={svgInfo.route}
-              alt={svgInfo.title}
-              class={imgStyles}
-            />
+            <img src={svgInfo.route} alt={svgInfo.title} class={imgStyles} />
             <Button
               class="justify-between"
               title="Download logo"
@@ -212,11 +208,7 @@
 
         {#if typeof svgInfo.wordmark === "string" && svgInfo.wordmark !== undefined}
           <div class={cardDownloadStyles}>
-            <img
-              src={svgInfo.wordmark}
-              alt={svgInfo.title}
-              class={imgStyles}
-            />
+            <img src={svgInfo.wordmark} alt={svgInfo.title} class={imgStyles} />
             <Button
               class="justify-between"
               title="Download Wordmark logo"

--- a/src/components/svgs/downloadSvg.svelte
+++ b/src/components/svgs/downloadSvg.svelte
@@ -123,7 +123,7 @@
         {#if typeof svgInfo.route === "string"}
           <div class={cardDownloadStyles}>
             <img
-              src={isDarkTheme() ? svgInfo.route : svgInfo.route}
+              src={svgInfo.route}
               alt={svgInfo.title}
               class={imgStyles}
             />
@@ -213,7 +213,7 @@
         {#if typeof svgInfo.wordmark === "string" && svgInfo.wordmark !== undefined}
           <div class={cardDownloadStyles}>
             <img
-              src={isDarkTheme() ? svgInfo.wordmark : svgInfo.wordmark}
+              src={svgInfo.wordmark}
               alt={svgInfo.title}
               class={imgStyles}
             />

--- a/src/routes/api/svgs/svgr/+server.ts
+++ b/src/routes/api/svgs/svgr/+server.ts
@@ -13,7 +13,10 @@ export const POST = async ({ request }: RequestEvent) => {
     const body = await request.json();
 
     if (!body.code || !body.name) {
-      return json({ error: "Missing required fields: code and name" }, { status: 400 });
+      return json(
+        { error: "Missing required fields: code and name" },
+        { status: 400 },
+      );
     }
 
     let svgCode = body.code;

--- a/src/routes/api/svgs/svgr/+server.ts
+++ b/src/routes/api/svgs/svgr/+server.ts
@@ -12,6 +12,10 @@ export const POST = async ({ request }: RequestEvent) => {
   try {
     const body = await request.json();
 
+    if (!body.code || !body.name) {
+      return json({ error: "Missing required fields: code and name" }, { status: 400 });
+    }
+
     let svgCode = body.code;
     const typescript = body.typescript;
     const name = body.name.replace(/[^a-zA-Z0-9]/g, "");

--- a/src/templates/getSource.ts
+++ b/src/templates/getSource.ts
@@ -9,7 +9,9 @@ export const getSource = async (params: SourceParams) => {
   if (!params.url) return "";
   const response = await fetch(params.url);
   if (!response.ok) {
-    throw new Error(`Failed to fetch SVG: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Failed to fetch SVG: ${response.status} ${response.statusText}`,
+    );
   }
   const content = await response.text();
   if (!params.optimize) return content;

--- a/src/templates/getSource.ts
+++ b/src/templates/getSource.ts
@@ -6,7 +6,11 @@ interface SourceParams {
 }
 
 export const getSource = async (params: SourceParams) => {
-  const response = await fetch(params.url || "");
+  if (!params.url) return "";
+  const response = await fetch(params.url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch SVG: ${response.status} ${response.statusText}`);
+  }
   const content = await response.text();
   if (!params.optimize) return content;
   const optimizedContent = optimizeSvg({ svgCode: content });


### PR DESCRIPTION
Hi @pheralb!

Thanks for building such a great project. I found and fixed 4 bugs that affect the download and copy functionality:

getSource.ts — Added response.ok check: Previously, error pages (404, 500) were being processed as valid SVG content, causing corrupt downloads. Now it throws an error when the fetch fails.

downloadSvg.svelte — Removed redundant ternaries: Expressions like isDarkTheme() ? route : route always returned the same value regardless of theme. Simplified to just use the value directly.

/api/svgs/svgr/+server.ts — Added input validation: Sending a POST request without code or name fields caused a 500 error. Now it returns a proper 400 response with a clear error message.

copySvg.svelte — Added error handling to converters: React, Angular, Web, and Astro converters did not have try/catch blocks. If getSource() failed, isLoading was never reset, leaving the user with an infinite spinner. Now all converters properly handle errors and reset the loading state.

All fixes include proper error handling and follow the existing code patterns. Let me know if you have any questions!