### PR TITLE
fix: convert fill-opacity to fillOpacity in React SVG parser

### DIFF
--- a/src/utils/parseReactSvgContent.ts
+++ b/src/utils/parseReactSvgContent.ts
@@ -26,6 +26,7 @@ const Attributes: Record<string, string> = {
   "xlink:href": "xlinkHref",
   "flood-opacity": "floodOpacity",
   "flood-color": "floodColor",
+  "fill-opacity": "fillOpacity",
 };
 
 const convertStyleStringToObject = (styleString: string): string => {


### PR DESCRIPTION
## Summary

This PR adds the missing `fill-opacity` → `fillOpacity` attribute mapping when converting SVGs to React components.

Without this mapping, SVGs using the `fill-opacity` attribute (such as the Supabase logo) generate invalid JSX.

## Changes

- Add `fill-opacity` → `fillOpacity` to the React SVG attribute mappings.

## Example

Before:

```jsx
<path fill-opacity="0.2" />
```

After:

```jsx
<path fillOpacity="0.2" />
```