### PR TITLE
fix: move Retain entry to the end of the array

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -2,19 +2,6 @@ import type { iSVG } from "@/types/svg";
 
 export const svgs: iSVG[] = [
   {
-    title: "Retain",
-    category: ["Analytics", "Software"],
-    route: {
-      light: "/library/retain-light.svg",
-      dark: "/library/retain-dark.svg",
-    },
-    wordmark: {
-      light: "/library/retain-wordmark-light.svg",
-      dark: "/library/retain-wordmark-dark.svg",
-    },
-    url: "https://retain.so/",
-  },
-  {
     title: 'Ossium',
     category: 'Software',
     route: '/library/ossium_logo.svg',
@@ -5183,5 +5170,18 @@ export const svgs: iSVG[] = [
       dark: "/library/mastra-wordmark-dark.svg",
     },
     url: "https://mastra.ai/",
+  },
+  {
+    title: "Retain",
+    category: ["Analytics", "Software"],
+    route: {
+      light: "/library/retain-light.svg",
+      dark: "/library/retain-dark.svg",
+    },
+    wordmark: {
+      light: "/library/retain-wordmark-light.svg",
+      dark: "/library/retain-wordmark-dark.svg",
+    },
+    url: "https://retain.so/",
   },
 ];


### PR DESCRIPTION
Moves the Retain entry from the top of the array to the end. No content changes: same 13 lines removed and re-added.

`svgsData` in `src/data/index.ts` assigns `id` from the array index, and both the home page and `/directory/[category]` sort by `b.id - a.id`. At index 0 the entry sorts last everywhere, which is the opposite of what "Latest" should show for the most recently merged logo.

The last entries in the array are Depot, TanStack and Mastra, in merge order. This puts Retain where it belongs in that sequence. I added it at the top in #1035 by mistake.
